### PR TITLE
Convert mappings values to plain java strings to fix issue with new forge gradle change

### DIFF
--- a/1.20.1/ide_runs.gradle
+++ b/1.20.1/ide_runs.gradle
@@ -1,7 +1,7 @@
 
 minecraft {
 
-    mappings channel: "${mapping_channel}", version: "${mapping_version}-${minecraft_version}"
+    mappings channel: "${mapping_channel}".toString(), version: "${mapping_version}-${minecraft_version}".toString()
 
     runs {
         client {

--- a/1.20.1/ide_runs_no_mixin.gradle
+++ b/1.20.1/ide_runs_no_mixin.gradle
@@ -1,7 +1,7 @@
 
 minecraft {
 
-    mappings channel: "${mapping_channel}", version: "${mapping_version}-${minecraft_version}"
+    mappings channel: "${mapping_channel}".toString(), version: "${mapping_version}-${minecraft_version}".toString()
 
     runs {
         client {


### PR DESCRIPTION
Passing `GStringImpl`s now causes an error because of this change: https://github.com/MinecraftForge/ForgeGradle/commit/edf7bf31cc1f555410ef5687b83190a486573546#diff-835e926ae7fb3c972d22b7f8f5d6a15914f8ec6c9a830d57f54d0b0e5a60e93eR93-R97